### PR TITLE
Enable Apple Silicon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,23 @@ pip install -r requirements.txt
 pip install flash_attn==2.5.8 --no-build-isolation
 ```
 
+<details>
+<summary>Running on Apple&nbsp;Silicon (M‑series)</summary>
+
+```
+conda create -n bagel python=3.10 -y
+conda activate bagel
+# Install PyTorch with MPS support
+pip install torch==2.5.1 torchvision==0.20.1
+# Install other dependencies (flash_attn and bitsandbytes are skipped)
+pip install -r requirements.txt
+```
+
+Use `python app.py` to launch the demo. Quantized modes require CUDA and are
+not available on macOS.
+
+</details>
+
 2️⃣  Download pretrained checkpoint
 ```python
 from huggingface_hub import snapshot_download

--- a/inferencer.py
+++ b/inferencer.py
@@ -227,7 +227,13 @@ class InterleaveInferencer:
         cfg_text_context = deepcopy(gen_context)
         cfg_img_context = deepcopy(gen_context)
 
-        with torch.autocast(device_type="cuda", enabled=True, dtype=torch.bfloat16):
+        device_type = "cuda" if torch.cuda.is_available() else (
+            "mps" if torch.backends.mps.is_available() else "cpu"
+        )
+        autocast_dtype = torch.bfloat16 if device_type == "cuda" else (
+            torch.float16 if device_type == "mps" else torch.float32
+        )
+        with torch.autocast(device_type=device_type, enabled=device_type != "cpu", dtype=autocast_dtype):
             if think:
                 if understanding_output:
                     system_prompt = VLM_THINK_SYSTEM_PROMPT 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ gradio
 setuptools
 wheel
 ninja
-bitsandbytes
+bitsandbytes ; sys_platform != 'darwin'
 xlsxwriter
-triton ; sys_platform != 'win32'
+triton ; sys_platform == 'linux'
 triton-windows ; sys_platform == 'win32'


### PR DESCRIPTION
## Summary
- add instructions for Apple silicon in README
- relax requirements for macOS
- auto-select CUDA/MPS/CPU in `inferencer.py`
- enable CPU/MPS loading logic in `app.py`

## Testing
- `python -m py_compile app.py inferencer.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'utils')*

------
https://chatgpt.com/codex/tasks/task_e_6859b8270260832497563f36f126929f