### PR TITLE
Add Apple MPS and fallback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,27 @@ pip install -r requirements.txt
 pip install flash_attn==2.5.8 --no-build-isolation
 ```
 
+<details>
+<summary>Running on Apple Silicon (M-series)</summary>
+
+```
+conda create -n bagel python=3.10 -y
+conda activate bagel
+# Install PyTorch with MPS support
+pip install torch==2.5.1 torchvision==0.20.1
+# Install other dependencies (GPU-only packages are skipped)
+pip install -r requirements.txt
+# `flash_attn` and `bitsandbytes` won't be installed. The code falls back to
+# PyTorch attention when flash_attn is missing. `decord` has no prebuilt wheel
+# for Apple Silicon; remove it from `requirements.txt` or build from source if
+# you need video features.
+```
+
+Use `python app.py` to launch the demo. Quantized modes require CUDA and are
+not available on macOS.
+
+</details>
+
 2️⃣  Download pretrained checkpoint
 ```python
 from huggingface_hub import snapshot_download

--- a/data/video_utils.py
+++ b/data/video_utils.py
@@ -16,7 +16,11 @@ import random
 import re
 
 import numpy as np
-import decord
+try:
+    import decord  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    decord = None
+    print("Warning: decord not found. Video features will be unavailable.")
 from PIL import Image
 
 
@@ -61,6 +65,8 @@ def get_frame_indices(num_frames, vlen, sample='rand', fix_start=None, input_fps
 
 
 def read_frames_decord(video_path, num_frames, sample='rand', fix_start=None, clip=None, min_num_frames=4):
+    if decord is None:
+        raise ImportError("decord is required for video reading. Install from source or remove video features.")
     video_reader = decord.VideoReader(video_path, num_threads=1)
     vlen = len(video_reader)
     fps = video_reader.get_avg_fps()
@@ -127,6 +133,8 @@ class FrameSampler:
 
 
 def decode_video_byte(video_bytes):
+    if decord is None:
+        raise ImportError("decord is required for video decoding. Install from source or remove video features.")
     video_stream = io.BytesIO(video_bytes)
     vr = decord.VideoReader(video_stream)
     return vr
@@ -134,6 +142,8 @@ def decode_video_byte(video_bytes):
 
 def sample_mp4_frames(mp4_p, n_frames=None, fps=None, return_frame_indices=False, random_sample=False):
     if isinstance(mp4_p, str):
+        if decord is None:
+            raise ImportError("decord is required for video decoding. Install from source or remove video features.")
         vr = decord.VideoReader(mp4_p, num_threads=1)
     elif isinstance(mp4_p, decord.video_reader.VideoReader):
         vr = mp4_p
@@ -156,6 +166,8 @@ def sample_mp4_frames(mp4_p, n_frames=None, fps=None, return_frame_indices=False
 
 def sample_mp4_frames_by_indices(mp4_p, frame_indices: list):
     if isinstance(mp4_p, str):
+        if decord is None:
+            raise ImportError("decord is required for video decoding. Install from source or remove video features.")
         vr = decord.VideoReader(mp4_p, num_threads=1)
     elif isinstance(mp4_p, decord.video_reader.VideoReader):
         vr = mp4_p

--- a/eval/gen/gedit/viescore/__init__.py
+++ b/eval/gen/gedit/viescore/__init__.py
@@ -1,7 +1,4 @@
-import sys
-sys.path.insert(0, 'viescore')
-
-from utils import (
+from .utils import (
     mllm_output_to_dict
 )
 import math

--- a/eval/gen/rise/gpt_eval.py
+++ b/eval/gen/rise/gpt_eval.py
@@ -10,7 +10,7 @@ import time
 import re
 import openai
 import pandas as pd
-from utils import *
+from .utils import *
 
 openai.api_key = os.getenv('OPENAI_API_KEY')
 

--- a/inferencer.py
+++ b/inferencer.py
@@ -227,7 +227,13 @@ class InterleaveInferencer:
         cfg_text_context = deepcopy(gen_context)
         cfg_img_context = deepcopy(gen_context)
 
-        with torch.autocast(device_type="cuda", enabled=True, dtype=torch.bfloat16):
+        device_type = "cuda" if torch.cuda.is_available() else (
+            "mps" if torch.backends.mps.is_available() else "cpu"
+        )
+        autocast_dtype = torch.bfloat16 if device_type == "cuda" else (
+            torch.float16 if device_type == "mps" else torch.float32
+        )
+        with torch.autocast(device_type=device_type, enabled=device_type != "cpu", dtype=autocast_dtype):
             if think:
                 if understanding_output:
                     system_prompt = VLM_THINK_SYSTEM_PROMPT 

--- a/modeling/bagel/siglip_navit.py
+++ b/modeling/bagel/siglip_navit.py
@@ -15,7 +15,51 @@ from torch import nn
 from transformers.activations import ACT2FN
 from modeling.siglip.configuration_siglip import SiglipVisionConfig as _SiglipVisionConfig
 from modeling.siglip.modeling_siglip import SiglipAttention, SiglipPreTrainedModel
-from flash_attn import flash_attn_varlen_func
+try:
+    from flash_attn import flash_attn_varlen_func  # type: ignore
+    _flash_attn_available = True
+except Exception:  # pragma: no cover - optional dependency
+    flash_attn_varlen_func = None  # type: ignore
+    _flash_attn_available = False
+    print("Warning: flash_attn not found. Falling back to scaled_dot_product_attention.")
+
+
+def flash_attn_varlen(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    causal: bool,
+):
+    if _flash_attn_available and q.is_cuda:
+        return flash_attn_varlen_func(
+            q=q,
+            k=k,
+            v=v,
+            cu_seqlens_q=cu_seqlens_q.to(torch.int32),
+            cu_seqlens_k=cu_seqlens_k.to(torch.int32),
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            causal=causal,
+        )
+
+    outputs = []
+    num_seq = cu_seqlens_q.numel() - 1
+    for i in range(num_seq):
+        qs = q[cu_seqlens_q[i] : cu_seqlens_q[i + 1]]
+        ks = k[cu_seqlens_k[i] : cu_seqlens_k[i + 1]]
+        vs = v[cu_seqlens_k[i] : cu_seqlens_k[i + 1]]
+        out = torch.nn.functional.scaled_dot_product_attention(
+            qs.unsqueeze(0).transpose(1, 2),
+            ks.unsqueeze(0).transpose(1, 2),
+            vs.unsqueeze(0).transpose(1, 2),
+            is_causal=causal,
+        )
+        outputs.append(out.transpose(1, 2).squeeze(0))
+    return torch.cat(outputs, dim=0)
 
 
 class SiglipVisionConfig(_SiglipVisionConfig):
@@ -229,7 +273,7 @@ class SiglipFlashAttention2(SiglipAttention):
             query_states = torch.cat([qh, qw], dim=-1)
             key_states = torch.cat([kh, kw], dim=-1)
 
-        attn_output = flash_attn_varlen_func(
+        attn_output = flash_attn_varlen(
             query_states.to(torch.bfloat16),
             key_states.to(torch.bfloat16),
             value_states.to(torch.bfloat16),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-decord==0.6.0
+decord==0.6.0 ; sys_platform != 'darwin'
 einops==0.8.1
 huggingface_hub==0.29.1
 matplotlib==3.7.0
@@ -20,7 +20,7 @@ gradio
 setuptools
 wheel
 ninja
-bitsandbytes
+bitsandbytes ; sys_platform != 'darwin'
 xlsxwriter
-triton ; sys_platform != 'win32'
+triton ; sys_platform == 'linux'
 triton-windows ; sys_platform == 'win32'


### PR DESCRIPTION
## Summary
- document Apple silicon setup instructions
- add fallback device map logic in `app.py`
- handle missing `decord` and `flash_attn`
- fallback to PyTorch attention when flash_attn missing
- adjust requirements for macOS compatibility

## Testing
- `python -m py_compile app.py data/video_utils.py eval/gen/gedit/viescore/__init__.py eval/gen/rise/gpt_eval.py inferencer.py modeling/bagel/qwen2_navit.py modeling/bagel/siglip_navit.py`

------
https://chatgpt.com/codex/tasks/task_e_6859d1013e2083248a393ea5b0f4b09b